### PR TITLE
ATED-3855: Remove unused contact-frontend

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -36,7 +36,7 @@ timeoutCountdown = 180 //How long the timeout countdown should appear before the
 
 application.router = prod.Routes
 
-play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9032 www.google-analytics.com data:"
+play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9250 localhost:9032 www.google-analytics.com data:"
 
 controllers {
   controllers.AssetsController = {
@@ -90,10 +90,6 @@ microservice {
         port = 8400
         domain = keystore
       }
-    }
-    contact-frontend {
-      host = localhost
-      port = 9250
     }
     auth {
       host = localhost
@@ -157,6 +153,10 @@ microservice {
       agentConfirmationUrl: "http://localhost:9771/capital-gains-tax/subscription/agent/registered/subscribe"
     }
   }
+}
+
+contact-frontend {
+  host = "http://localhost:9250"
 }
 
 delegated-service {


### PR DESCRIPTION
Moved contact-frontend config and added exclusion to contentSecurityPolicy