### PR TITLE
DL-2733 Fixed no active session url and service type parsing

### DIFF
--- a/app/config/BCHandler.scala
+++ b/app/config/BCHandler.scala
@@ -30,6 +30,16 @@ class BCHandlerImpl @Inject()(val messagesApi: MessagesApi,
 trait BCHandler extends FrontendErrorHandler with I18nSupport {
   implicit val appConfig: ApplicationConfig
 
-  override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit request: Request[_]): Html =
-    views.html.global_error(pageTitle, heading, message, request.uri.split("/").last)
+  def findServiceInRequest(request: Request[_]): String = {
+    val requestParts = request.uri.split("/")
+    val serviceList = appConfig.serviceList
+
+    requestParts.find(part => serviceList.contains(part.toLowerCase)).getOrElse("unknownservice")
+  }
+
+  override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit request: Request[_]): Html = {
+    val service = findServiceInRequest(request)
+
+    views.html.global_error(pageTitle, heading, message, service)
+  }
 }

--- a/app/controllers/auth/AuthActions.scala
+++ b/app/controllers/auth/AuthActions.scala
@@ -38,9 +38,10 @@ trait AuthActions extends AuthorisedFunctions {
 
   def continueURL(serviceName: String): String = appConfig.continueURL(serviceName)
 
+  lazy val origin: String = appConfig.appName
   def loginParams(serviceName: String)(implicit request: Request[AnyContent]): Map[String, Seq[String]] = Map(
-    "continue" -> Seq(loginURL),
-    "origin" -> Seq(continueURL(serviceName))
+    "continue" -> Seq(continueURL(serviceName)),
+    "origin" -> Seq(origin)
   )
 
   private def isValidUrl(serviceName: String): Boolean = {

--- a/test/config/BCHandlerSpec.scala
+++ b/test/config/BCHandlerSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.{OneServerPerSuite, PlaySpec}
+import play.api.i18n.MessagesApi
+import play.api.test.FakeRequest
+import org.mockito.Mockito._
+
+class BCHandlerSpec extends PlaySpec with OneServerPerSuite with MockitoSugar {
+
+  val mockAppConfig = mock[ApplicationConfig]
+
+  val bcHandler: BCHandler = new BCHandler {
+    val messagesApi = mock[MessagesApi]
+    val appConfig = mockAppConfig
+  }
+
+  "findServiceInRequest" should {
+    "find a service in a request" when {
+      "the url contains a service name" in {
+        when(mockAppConfig.serviceList).thenReturn(List("ated"))
+
+        val service = bcHandler.findServiceInRequest(
+          FakeRequest(controllers.routes.BusinessVerificationController.businessVerification("ated"))
+        )
+
+        service mustBe "ated"
+      }
+
+      "the url contains a service name not at the end" in {
+        when(mockAppConfig.serviceList).thenReturn(List("awrs", "ated"))
+
+        val service = bcHandler.findServiceInRequest(
+          FakeRequest(controllers.nonUKReg.routes.BusinessRegController.register("awrs", "businessType"))
+        )
+
+        service mustBe "awrs"
+      }
+    }
+
+    "cannot find a service in a request" when {
+      "the url does not contain the service name" in {
+        when(mockAppConfig.serviceList).thenReturn(List("ated"))
+
+        val service = bcHandler.findServiceInRequest(
+          FakeRequest(controllers.routes.BusinessVerificationController.businessVerification("fakeservice"))
+        )
+
+        service mustBe "unknownservice"
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
# DL-2733 Fixed no active session url and service type parsing

**Bug fix**

* Amended continue session url for when there is no active session for a user
* Adjusted service type parsing for error page to be more responsive to URLs, and fail-safe

## Checklist Reviewee (add name here)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
 ## Checklist Reviewer (add name here)
 
  - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
  - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
  - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
  - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
  - [x]  I've run a dependency check to ensure all dependencies are up to date
