### PR TITLE
DL-3820 Fix NonUkPostcode verifier format

### DIFF
--- a/app/connectors/NewBusinessCustomerConnector.scala
+++ b/app/connectors/NewBusinessCustomerConnector.scala
@@ -24,7 +24,7 @@ import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.play.audit.model.{Audit, EventTypes}
+import uk.gov.hmrc.play.audit.model.EventTypes
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 import utils.GovernmentGatewayConstants
 

--- a/app/controllers/BusinessCustomerController.scala
+++ b/app/controllers/BusinessCustomerController.scala
@@ -25,7 +25,6 @@ import play.api.i18n.I18nSupport
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 import scala.concurrent.ExecutionContext

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -25,7 +25,6 @@ import play.api.libs.json.{JsError, JsSuccess}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.BusinessMatchingService
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 import scala.concurrent.ExecutionContext

--- a/app/controllers/ReviewDetailsController.scala
+++ b/app/controllers/ReviewDetailsController.scala
@@ -16,13 +16,13 @@
 
 package controllers
 
-import config.{ApplicationConfig, BCHandler}
+import config.ApplicationConfig
 import connectors.{BackLinkCacheConnector, DataCacheConnector}
 import controllers.auth.AuthActions
 import javax.inject.Inject
 import play.api.Logger
 import play.api.i18n.Messages
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.AgentRegistrationService
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController

--- a/app/controllers/nonUKReg/AgentRegisterNonUKClientController.scala
+++ b/app/controllers/nonUKReg/AgentRegisterNonUKClientController.scala
@@ -28,12 +28,10 @@ import play.api.Logger
 import play.api.i18n.Messages
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import utils.BusinessCustomerConstants.BusinessRegDetailsId
 
 import scala.concurrent.ExecutionContext
-import scala.util.{Success, Try}
 
 class AgentRegisterNonUKClientController @Inject()(val authConnector: AuthConnector,
                                                    val backLinkCacheConnector: BackLinkCacheConnector,

--- a/app/controllers/nonUKReg/BusinessRegController.scala
+++ b/app/controllers/nonUKReg/BusinessRegController.scala
@@ -16,7 +16,7 @@
 
 package controllers.nonUKReg
 
-import config.{ApplicationConfig, BCUtils}
+import config.ApplicationConfig
 import connectors.{BackLinkCacheConnector, BusinessRegCacheConnector}
 import controllers.BackLinkController
 import controllers.auth.AuthActions
@@ -26,7 +26,6 @@ import javax.inject.Inject
 import models.{BusinessRegistration, BusinessRegistrationDisplayDetails, StandardAuthRetrievals}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import utils.BusinessCustomerConstants.BusinessRegDetailsId
 

--- a/app/controllers/nonUKReg/NRLQuestionController.scala
+++ b/app/controllers/nonUKReg/NRLQuestionController.scala
@@ -25,7 +25,6 @@ import javax.inject.Inject
 import models.NRLQuestion
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import utils.BusinessCustomerConstants.NrlFormId
 

--- a/app/controllers/nonUKReg/PaySAQuestionController.scala
+++ b/app/controllers/nonUKReg/PaySAQuestionController.scala
@@ -25,7 +25,6 @@ import javax.inject.{Inject, Provider}
 import models.PaySAQuestion
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import utils.BusinessCustomerConstants.PaySaDetailsId
 

--- a/app/metrics/MetricsService.scala
+++ b/app/metrics/MetricsService.scala
@@ -16,8 +16,8 @@
 
 package metrics
 
-import com.codahale.metrics.{Counter, MetricRegistry, Timer}
 import com.codahale.metrics.Timer.Context
+import com.codahale.metrics.{Counter, MetricRegistry, Timer}
 import com.kenshoo.play.metrics.Metrics
 import javax.inject.Inject
 import metrics.MetricsEnum.MetricsEnum

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,11 +5,11 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.8.0",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.14.0",
     "uk.gov.hmrc" %% "domain" % "5.9.0-play-26",
     "uk.gov.hmrc" %% "play-partials" % "6.11.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "8.10.0-play-26",
-    "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",
+    "uk.gov.hmrc" %% "play-ui" % "8.11.0-play-26",
+    "uk.gov.hmrc" %% "http-caching-client" % "9.1.0-play-26",
     "uk.gov.hmrc" %% "auth-client" % "3.0.0-play-26",
     "com.typesafe.play" %% "play-json-joda" % "2.6.14",
     "uk.gov.hmrc" %% "govuk-template" % "5.55.0-play-26"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksam
 
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.7.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -20,6 +20,6 @@ addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
DL-3820

Bug fix

Fixing issue whereby overseas subscription was creating known facts verifiers which could contain leading and trailing spaces (if applied by the user to the postcode field). We also tweaked the Regex for NonUKPostcode to only allow 1 space within the allowable string as opposed to multiple spaces which would have caused match issues

General tidy on redundant imports observed during making changes

## Checklist Reviewee (add name here)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
 ## Checklist Reviewer (add name here)
 
  - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
  - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
  - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
  - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
  - [ ]  I've run a dependency check to ensure all dependencies are up to date
