### PR TITLE
DL-4518 Enhanced BCHandler to show 404 for invalid service name

### DIFF
--- a/app/config/BCHandler.scala
+++ b/app/config/BCHandler.scala
@@ -20,7 +20,7 @@ import java.net.URLEncoder
 
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, Messages, MessagesApi}
-import play.api.mvc.Results.{NotFound, Ok}
+import play.api.mvc.Results.NotFound
 import play.api.mvc.{Request, RequestHeader, Result}
 import play.twirl.api.Html
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler

--- a/app/config/BCHandler.scala
+++ b/app/config/BCHandler.scala
@@ -20,7 +20,8 @@ import java.net.URLEncoder
 
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, Messages, MessagesApi}
-import play.api.mvc.Request
+import play.api.mvc.Results.{NotFound, Ok}
+import play.api.mvc.{Request, RequestHeader, Result}
 import play.twirl.api.Html
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
 import utils.SessionUtils
@@ -48,5 +49,21 @@ trait BCHandler extends FrontendErrorHandler with I18nSupport {
       appConfig,
       URLEncoder.encode(request.uri, "UTF8")
   )
+  }
+
+  override def notFoundTemplate(implicit request: Request[_]): Html = {
+    appConfig.templateError(
+      Messages("bc.notFound.error.title"),
+      Messages("bc.notFound.error.header"),
+      Messages("bc.notFound.error.message"),
+      SessionUtils.findServiceInRequest(request),
+      appConfig,
+      URLEncoder.encode(request.uri, "UTF8")
+    )
+  }
+
+  override def resolveError(rh: RequestHeader, ex: Throwable): Result = ex.getMessage match {
+    case "Service name not found" => NotFound(notFoundTemplate(Request.apply(rh, "")))
+    case _ => super.resolveError(rh, ex)
   }
 }

--- a/app/controllers/auth/AuthActions.scala
+++ b/app/controllers/auth/AuthActions.scala
@@ -20,11 +20,11 @@ import config.ApplicationConfig
 import models.StandardAuthRetrievals
 import play.api.Logging
 import play.api.mvc.Results.Redirect
-import play.api.mvc.{AnyContent, Request, Result, Results}
+import play.api.mvc.{AnyContent, Request, Result}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.auth.core.{NoActiveSession, _}
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
 import utils.ValidateUri
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -60,7 +60,7 @@ trait AuthActions extends AuthorisedFunctions with Logging {
                    (implicit req: Request[AnyContent], ec: ExecutionContext, hc: HeaderCarrier): Future[Result] = {
     if (!isValidUrl(serviceName)) {
       logger.error(s"[authorisedFor] Given invalid service name of $serviceName")
-      Future.successful(Results.NotFound)
+      throw new NotFoundException("Service name not found")
     } else {
       authorised((AffinityGroup.Organisation or AffinityGroup.Agent or Enrolment("IR-SA")) and ConfidenceLevel.L50)
         .retrieve(allEnrolments and affinityGroup and credentials and groupIdentifier) {

--- a/conf/messages
+++ b/conf/messages
@@ -403,6 +403,10 @@ bc.generic.error.header = Sorry, there is a problem with the service
 bc.generic.error.title = Sorry, there is a problem with the service
 bc.generic.error.message = Try again later.
 
+bc.notFound.error.header = This page can’t be found
+bc.notFound.error.title = Page not found - 404
+bc.notFound.error.message = Please check that you have entered the correct web address.
+
 zero = 0
 one = 1
 two = 2

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "3.0.0",
     "uk.gov.hmrc" %% "domain" % "5.10.0-play-27",
-    "uk.gov.hmrc" %% "play-partials" % "6.11.0-play-27",
+    "uk.gov.hmrc" %% "play-partials" % "7.0.0-play-27",
     "uk.gov.hmrc" %% "play-ui" % "8.15.0-play-27",
     "uk.gov.hmrc" %% "http-caching-client" % "9.1.0-play-27",
     "uk.gov.hmrc" %% "auth-client" % "3.2.0-play-27",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,14 +5,14 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "2.25.0",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "3.0.0",
     "uk.gov.hmrc" %% "domain" % "5.10.0-play-27",
     "uk.gov.hmrc" %% "play-partials" % "6.11.0-play-27",
-    "uk.gov.hmrc" %% "play-ui" % "8.13.0-play-27",
+    "uk.gov.hmrc" %% "play-ui" % "8.15.0-play-27",
     "uk.gov.hmrc" %% "http-caching-client" % "9.1.0-play-27",
     "uk.gov.hmrc" %% "auth-client" % "3.2.0-play-27",
     "com.typesafe.play" %% "play-json-joda" % "2.7.4",
-    "uk.gov.hmrc" %% "govuk-template" % "5.58.0-play-27",
+    "uk.gov.hmrc" %% "govuk-template" % "5.59.0-play-27",
     compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.1" cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full
   )

--- a/test/config/BCHandlerSpec.scala
+++ b/test/config/BCHandlerSpec.scala
@@ -42,4 +42,15 @@ class BCHandlerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSug
       document.getElementsByTag("article").text() must be("Try again later.")
     }
   }
-}
+  "calling onClientError for a page not found" must {
+
+    implicit val request = FakeRequest()
+    val errorHandler = new BCHandlerImpl(mcc.messagesApi, appConfig)
+    val result = errorHandler.notFoundTemplate
+    val document = Jsoup.parse(contentAsString(result))
+
+      "render page in English" in {
+        document.title must be("Page not found - 404 - GOV.UK")
+      }
+    }
+  }

--- a/test/controllers/BusinessVerificationControllerSpec.scala
+++ b/test/controllers/BusinessVerificationControllerSpec.scala
@@ -35,6 +35,7 @@ import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import services.BusinessMatchingService
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.NotFoundException
 
 import scala.concurrent.Future
 
@@ -105,8 +106,11 @@ class BusinessVerificationControllerSpec extends PlaySpec with GuiceOneServerPer
         }
 
         "respond with NotFound when invalid service is in uri" in new Setup {
-          businessVerificationWithAuthorisedUser(controller)(result =>
-            status(result) must be(NOT_FOUND), serviceName = invalidService)
+          intercept[NotFoundException] {
+
+            businessVerificationWithAuthorisedUser(controller)(result =>
+              status(result) must be(NOT_FOUND), serviceName = invalidService)
+          }
         }
 
         "return Business Verification view for a user" in new Setup {

--- a/test/controllers/ReviewDetailsControllerSpec.scala
+++ b/test/controllers/ReviewDetailsControllerSpec.scala
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import services.AgentRegistrationService
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException}
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 
 import scala.concurrent.Future
@@ -275,9 +275,11 @@ class ReviewDetailsControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
 
           "respond with NotFound when invalid service is in uri" in {
             when(mockAgentRegistrationService.isAgentEnrolmentAllowed(ArgumentMatchers.eq("unknownServiceTest"))).thenReturn(false)
-            continueWithAuthorisedUser("unknownServiceTest") {
+            intercept[NotFoundException] {
+              continueWithAuthorisedUser("unknownServiceTest") {
               result =>
                 status(result) must be(NOT_FOUND)
+              }
             }
           }
 

--- a/test/controllers/nonUKReg/AgentRegisterNonUKClientControllerSpec.scala
+++ b/test/controllers/nonUKReg/AgentRegisterNonUKClientControllerSpec.scala
@@ -32,7 +32,7 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{AnyContentAsJson, Headers, MessagesControllerComponents, Result}
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
 import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 
@@ -230,8 +230,10 @@ class AgentRegisterNonUKClientControllerSpec extends PlaySpec with GuiceOneServe
 
         "respond with NotFound when invalid service is in uri" in new Setup {
           val inputJson = createJson()
-          submitWithAuthorisedUserSuccess(FakeRequest().withJsonBody(inputJson), invalidService, None, controller = controller) { result =>
-            status(result) must be(NOT_FOUND)
+          intercept[NotFoundException] {
+            submitWithAuthorisedUserSuccess(FakeRequest().withJsonBody(inputJson), invalidService, None, controller = controller) { result =>
+              status(result) must be(NOT_FOUND)
+            }
           }
         }
       }

--- a/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
@@ -33,6 +33,7 @@ import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.NotFoundException
 
 import scala.concurrent.Future
 
@@ -266,8 +267,10 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         "respond with NotFound when invalid service is in uri" in {
           val inputJson = createJson(postcode = "")
           when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-          submitWithAuthorisedAgent(invalidService, FakeRequest().withJsonBody(inputJson)) { result =>
-            status(result) must be(NOT_FOUND)
+          intercept[NotFoundException] {
+            submitWithAuthorisedAgent(invalidService, FakeRequest().withJsonBody(inputJson)) { result =>
+              status(result) must be(NOT_FOUND)
+            }
           }
         }
       }

--- a/test/controllers/nonUKReg/NRLQuestionControllerSpec.scala
+++ b/test/controllers/nonUKReg/NRLQuestionControllerSpec.scala
@@ -34,6 +34,7 @@ import play.api.mvc.{AnyContentAsJson, Headers, MessagesControllerComponents, Re
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.NotFoundException
 import views.html.nonUkReg.nrl_question
 
 import scala.concurrent.Future
@@ -76,8 +77,10 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
     "view" must {
 
       "respond with NotFound when invalid service is in uri" in {
-        viewWithAuthorisedClient(invalidService) { result =>
-          status(result) must be(NOT_FOUND)
+        intercept[NotFoundException] {
+          viewWithAuthorisedClient(invalidService) { result =>
+            status(result) must be(NOT_FOUND)
+          }
         }
       }
 
@@ -113,8 +116,10 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
 
       "respond with NotFound when invalid service is in uri" in {
         val fakeRequest = FakeRequest().withJsonBody(Json.parse("""{"paysSA": ""}"""))
-        continueWithAuthorisedClient(fakeRequest, invalidService) { result =>
-          status(result) must be(NOT_FOUND)
+        intercept[NotFoundException] {
+          continueWithAuthorisedClient(fakeRequest, invalidService) { result =>
+            status(result) must be(NOT_FOUND)
+          }
         }
       }
 

--- a/test/controllers/nonUKReg/PaySAQuestionControllerSpec.scala
+++ b/test/controllers/nonUKReg/PaySAQuestionControllerSpec.scala
@@ -36,6 +36,7 @@ import play.api.mvc.{AnyContentAsJson, Headers, MessagesControllerComponents, Re
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.NotFoundException
 
 import scala.concurrent.Future
 
@@ -78,8 +79,10 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
     "view" must {
 
       "respond with NotFound when invalid service is in uri" in {
-        viewWithAuthorisedClient(invalidService) { result =>
-          status(result) must be(NOT_FOUND)
+        intercept[NotFoundException] {
+          viewWithAuthorisedClient(invalidService) { result =>
+            status(result) must be(NOT_FOUND)
+          }
         }
       }
 
@@ -118,8 +121,10 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
       "respond with NotFound when invalid service is in uri" in {
         val fakeRequest = FakeRequest().withJsonBody(Json.parse("""{"paySA": ""}"""))
         when(mockBackLinkCache.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        continueWithAuthorisedClient(fakeRequest, invalidService) { result =>
-          status(result) must be(NOT_FOUND)
+        intercept[NotFoundException] {
+          continueWithAuthorisedClient(fakeRequest, invalidService) { result =>
+            status(result) must be(NOT_FOUND)
+          }
         }
       }
 


### PR DESCRIPTION
DL-4518 Enhanced BCHandler to show 404 for invalid service name

**Bug fix** 

404 pages were not being rendered correctly. This PR is to ensure that they display the correct message.

## Checklist Reviewee (add name here)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
 ## Checklist Reviewer (add name here)
 
  - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
  - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
  - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
  - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
  - [x]  I've run a dependency check to ensure all dependencies are up to date
