### PR TITLE
accessBusCust fix tracking consent issue locally

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -191,4 +191,5 @@ delegated-service {
 
 logout.url = "http://localhost:9553/bas-gateway/sign-out-without-state"
 cancelRedirectUrl: "https://www.gov.uk/"
-platform.frontend.host = "http://localhost:9923"
+
+tracking-consent-frontend.host = "http://localhost:12345"

--- a/test/acceptance/ReviewDetailsFeatureSpec.scala
+++ b/test/acceptance/ReviewDetailsFeatureSpec.scala
@@ -71,7 +71,7 @@ class ReviewDetailsFeatureSpec extends AnyFeatureSpec with GuiceOneServerPerSuit
       assert(document.select(".govuk-button").text === ("Confirm"))
       assert(document.getElementById("bus-reg-edit") === null)
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
 
     Scenario("return Review Details view for a user, when user can't be directly found with login credentials") {
@@ -104,7 +104,7 @@ class ReviewDetailsFeatureSpec extends AnyFeatureSpec with GuiceOneServerPerSuit
       assert(document.select(".govuk-button").text === "Confirm")
       assert(document.getElementById("bus-reg-edit") === null)
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
 
     Scenario("return Review Details view for an agent, when we directly found this") {
@@ -134,7 +134,7 @@ class ReviewDetailsFeatureSpec extends AnyFeatureSpec with GuiceOneServerPerSuit
 
       And("There is a link to the accessibility statement")
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
   }
 }

--- a/test/acceptance/ReviewDetailsNonUkAgentFeatureSpec.scala
+++ b/test/acceptance/ReviewDetailsNonUkAgentFeatureSpec.scala
@@ -86,7 +86,7 @@ class ReviewDetailsNonUkAgentFeatureSpec extends AnyFeatureSpec with GuiceOneSer
 
       And("There is a link to the accessibility statement")
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
 
   }

--- a/test/acceptance/nonUkReg/nrl_questionSpec.scala
+++ b/test/acceptance/nonUkReg/nrl_questionSpec.scala
@@ -64,7 +64,7 @@ class nrl_questionSpec extends AnyFeatureSpec with GuiceOneServerPerSuite with M
 
       And("There is a link to the accessibility statement")
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
   }
 }

--- a/test/acceptance/nonUkReg/overseas_company_registrationSpec.scala
+++ b/test/acceptance/nonUkReg/overseas_company_registrationSpec.scala
@@ -74,7 +74,7 @@ class overseas_company_registrationSpec extends AnyFeatureSpec with GuiceOneServ
 
       And("There is a link to the accessibility statement")
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
   }
 }

--- a/test/acceptance/nonUkReg/paySAQuestionSpec.scala
+++ b/test/acceptance/nonUkReg/paySAQuestionSpec.scala
@@ -63,7 +63,7 @@ class paySAQuestionSpec extends AnyFeatureSpec with GuiceOneServerPerSuite with 
 
       And("There is a link to the accessibility statement")
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
   }
 }

--- a/test/acceptance/nonUkReg/update_overseas_company_registrationSpec.scala
+++ b/test/acceptance/nonUkReg/update_overseas_company_registrationSpec.scala
@@ -78,7 +78,7 @@ class update_overseas_company_registrationSpec extends AnyFeatureSpec with Guice
 
       And("There is a link to the accessibility statement")
       assert(document.select(".govuk-footer__inline-list-item:nth-child(2) > a")
-        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=http%3A%2F%2Flocalhost%3A9923%2F")
+        .attr("href") === "http://localhost:12346/accessibility-statement/ated-subscription?referrerUrl=%2F")
     }
   }
 }

--- a/test/utils/ReferrerUtilsSpec.scala
+++ b/test/utils/ReferrerUtilsSpec.scala
@@ -17,6 +17,7 @@
 package utils
 
 import config.ApplicationConfig
+import org.mockito.MockitoSugar.{mock, when}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
@@ -29,8 +30,19 @@ class ReferrerUtilsSpec extends AnyWordSpecLike with Matchers with GuiceOneAppPe
 
   "getReferrer" should {
 
-    "return an encoded url containing the request app host and request path" in {
+    "return an encoded url containing a non defined platform host config val and request path" in {
       implicit val appConfig: ApplicationConfig = inject[ApplicationConfig]
+      implicit val request: MessagesRequest[AnyContent] =
+        new MessagesRequest[AnyContent](FakeRequest("GET", "/a-uri"), inject[MessagesApi])
+
+      getReferrer() should be("%2Fa-uri")
+    }
+
+
+    "return an encoded url containing a defined platform host config val and request path" in {
+      implicit val mockAppConfig: ApplicationConfig = mock[ApplicationConfig]
+      when(mockAppConfig.platformHost).thenReturn("http://localhost:9923")
+
       implicit val request: MessagesRequest[AnyContent] =
         new MessagesRequest[AnyContent](FakeRequest("GET", "/a-uri"), inject[MessagesApi])
 


### PR DESCRIPTION
accessBusCust

**Bug fix** 

Addressing a console error when running application locally that was causing a 404 to be thrown when trying to load assets for tracking consent relating to Accessibility link. This only affected local view and is not evident in the environments but causes the Accessibility Job tests to fail  

## Checklist Reviewee (Paul Anderson)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 
 ## Checklist Reviewer (add name here)
 
  - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
  - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
  - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
  - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
  - [ ]  I've run a dependency check to ensure all dependencies are up to date
