### PR TITLE
DL-6759 reformat country code file with vim

### DIFF
--- a/conf/country-code.properties
+++ b/conf/country-code.properties
@@ -1,4 +1,4 @@
-﻿AD=Andorra
+AD=Andorra
 AE=United Arab Emirates
 AF=Afghanistan
 AG=Antigua and Barbuda


### PR DESCRIPTION
Used vim -b conf/country-codes.properties to cleanse