### PR TITLE
DL-7795 bootstrap-play and play 2.8.15 upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val appDependencies: Seq[ModuleID] = AppDependencies()
 
 lazy val plugins: Seq[Plugins] = Seq(play.sbt.PlayScala, SbtDistributablesPlugin)
 lazy val playSettings: Seq[Setting[_]] = Seq.empty
-val silencerVersion = "1.7.1"
+val silencerVersion = "1.7.9"
 lazy val scoverageSettings = {
   import scoverage.ScoverageKeys
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val microservice: Project = Project(appName, file("."))
     defaultSettings(),
     scoverageSettings,
     scalacOptions += "-Ywarn-unused:-explicits,-implicits",
-    scalaVersion := "2.12.12",
+    scalaVersion := "2.12.15",
     libraryDependencies ++= appDependencies,
     retrieveManaged := true,
     majorVersion := 4,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,18 +5,18 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.20.0",
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.24.0",
     "uk.gov.hmrc"       %% "domain"                     % "8.1.0-play-28",
     "uk.gov.hmrc"       %% "play-partials"              % "8.3.0-play-28",
     "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.20.0-play-28",
     "uk.gov.hmrc"       %% "http-caching-client"        % "9.6.0-play-28",
     "com.typesafe.play" %% "play-json-joda"             % "2.9.2",
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.1" cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full
+    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.8" cross CrossVersion.full),
+    "com.github.ghik" % "silencer-lib" % "1.7.8" % Provided cross CrossVersion.full
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-28"  % "5.20.0"   % "test",
+    "uk.gov.hmrc" %% "bootstrap-test-play-28"  % "5.24.0"   % "test",
     "org.jsoup"   %  "jsoup"                   % "1.15.1"   % "test",
     "org.mockito" %  "mockito-core"            % "4.5.1"    % "test",
     "org.mockito" %% "mockito-scala"           % "1.17.7"   % "test",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,17 +8,15 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.24.0",
     "uk.gov.hmrc"       %% "domain"                     % "8.1.0-play-28",
     "uk.gov.hmrc"       %% "play-partials"              % "8.3.0-play-28",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.20.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.21.0-play-28",
     "uk.gov.hmrc"       %% "http-caching-client"        % "9.6.0-play-28",
-    "com.typesafe.play" %% "play-json-joda"             % "2.9.2",
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.8" cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib" % "1.7.8" % Provided cross CrossVersion.full
+    "com.typesafe.play" %% "play-json-joda"             % "2.9.2"
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-test-play-28"  % "5.24.0"   % "test",
     "org.jsoup"   %  "jsoup"                   % "1.15.1"   % "test",
-    "org.mockito" %  "mockito-core"            % "4.5.1"    % "test",
+    "org.mockito" %  "mockito-core"            % "4.6.1"    % "test",
     "org.mockito" %% "mockito-scala"           % "1.17.7"   % "test",
     "org.mockito" %% "mockito-scala-scalatest" % "1.17.7"   % "test"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.3")
 

--- a/test/builders/SessionBuilder.scala
+++ b/test/builders/SessionBuilder.scala
@@ -18,13 +18,13 @@ package builders
 
 import java.util.UUID
 
-import play.api.mvc.{AnyContentAsEmpty, AnyContentAsJson, Headers}
+import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, AnyContentAsJson, Headers}
 import play.api.test.FakeRequest
 
 object SessionBuilder {
 
 
-  def updateRequestWithSession(fakeRequest: FakeRequest[AnyContentAsJson], userId: String): FakeRequest[AnyContentAsJson] = {
+  def updateRequestWithSession(fakeRequest: FakeRequest[AnyContentAsFormUrlEncoded], userId: String): FakeRequest[AnyContentAsFormUrlEncoded] = {
     val sessionId = s"session-${UUID.randomUUID}"
     fakeRequest.withSession(
       "sessionId" -> sessionId,

--- a/test/controllers/BusinessVerificationValidationSpec.scala
+++ b/test/controllers/BusinessVerificationValidationSpec.scala
@@ -29,8 +29,10 @@ import play.api.test.{FakeRequest, Injecting}
 import services.BusinessMatchingService
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.domain.{SaUtr, SaUtrGenerator}
-
 import java.util.UUID
+
+import views.html.{business_lookup_LLP, business_lookup_LP, business_lookup_LTD, business_lookup_NRL, business_lookup_OBP, business_lookup_SOP, business_lookup_UIB, business_verification, details_not_found}
+
 import scala.concurrent.Future
 
 
@@ -49,15 +51,15 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
   val mockNrlQuestionConnector: NRLQuestionController = mock[NRLQuestionController]
   val mockReviewDetailsController: ReviewDetailsController = mock[ReviewDetailsController]
   val mockHomeController: HomeController = mock[HomeController]
-  val injectedViewInstance = inject[views.html.business_verification]
-  val injectedViewInstanceSOP = inject[views.html.business_lookup_SOP]
-  val injectedViewInstanceLTD = inject[views.html.business_lookup_LTD]
-  val injectedViewInstanceUIB = inject[views.html.business_lookup_UIB]
-  val injectedViewInstanceOBP = inject[views.html.business_lookup_OBP]
-  val injectedViewInstanceLLP = inject[views.html.business_lookup_LLP]
-  val injectedViewInstanceLP = inject[views.html.business_lookup_LP]
-  val injectedViewInstanceNRL = inject[views.html.business_lookup_NRL]
-  val injectedViewInstanceDetailsNotFound = inject[views.html.details_not_found]
+  val injectedViewInstance: business_verification = inject[views.html.business_verification]
+  val injectedViewInstanceSOP: business_lookup_SOP = inject[views.html.business_lookup_SOP]
+  val injectedViewInstanceLTD: business_lookup_LTD = inject[views.html.business_lookup_LTD]
+  val injectedViewInstanceUIB: business_lookup_UIB = inject[views.html.business_lookup_UIB]
+  val injectedViewInstanceOBP: business_lookup_OBP = inject[views.html.business_lookup_OBP]
+  val injectedViewInstanceLLP: business_lookup_LLP = inject[views.html.business_lookup_LLP]
+  val injectedViewInstanceLP: business_lookup_LP = inject[views.html.business_lookup_LP]
+  val injectedViewInstanceNRL: business_lookup_NRL = inject[views.html.business_lookup_NRL]
+  val injectedViewInstanceDetailsNotFound: details_not_found = inject[views.html.details_not_found]
 
   val appConfig: ApplicationConfig = inject[ApplicationConfig]
   implicit val mcc: MessagesControllerComponents = inject[MessagesControllerComponents]
@@ -269,13 +271,13 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     type BusinessType = String
 
     def nrlUtrRequest(utr: String = matchUtr.utr, businessName: String = "ACME"): FakeRequest[AnyContentAsFormUrlEncoded] =
-      request.withFormUrlEncodedBody("saUTR" -> s"$utr", "businessName" -> s"$businessName")
+      FakeRequest("POST", "/").withFormUrlEncodedBody("saUTR" -> s"$utr", "businessName" -> s"$businessName")
     def ctUtrRequest(ct: String = matchUtr.utr, businessName: String = "ACME"): FakeRequest[AnyContentAsFormUrlEncoded] =
-      request.withFormUrlEncodedBody("cotaxUTR" -> s"$ct", "businessName" -> s"$businessName")
+      FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$ct", "businessName" -> s"$businessName")
     def psaUtrRequest(psa: String = matchUtr.utr, businessName: String = "ACME"): FakeRequest[AnyContentAsFormUrlEncoded] =
-      request.withFormUrlEncodedBody("psaUTR" -> s"$psa", "businessName" -> s"$businessName")
+      FakeRequest("POST", "/").withFormUrlEncodedBody("psaUTR" -> s"$psa", "businessName" -> s"$businessName")
     def saUtrRequest(sa: String = matchUtr.utr, firstName: String = "A", lastName: String = "B"): FakeRequest[AnyContentAsFormUrlEncoded] =
-      request.withFormUrlEncodedBody("saUTR" -> s"$sa", "firstName" -> s"$firstName", "lastName" -> s"$lastName")
+      FakeRequest("POST", "/").withFormUrlEncodedBody("saUTR" -> s"$sa", "firstName" -> s"$firstName", "lastName" -> s"$lastName")
 
     val formValidationInputDataSetOrg: Seq[(MustTestMessage, Seq[(InTestMessage, BusinessType, InputRequest, ErrorMessage)])] =
       Seq(
@@ -384,14 +386,14 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     "if the Ordinary Business Partnership form is successfully validated:" must {
       "for successful match, status should be 303 and user should be redirected to review details page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserSuccessOrg("OBP", request.withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$matchUtr"), controller) {
+        submitWithAuthorisedUserSuccessOrg("OBP", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$matchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
         }
       }
       "for unsuccessful match, status should be Redirect and user should be on details not found page" in new Setup {
-        submitWithAuthorisedUserFailure("OBP", request.withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$noMatchUtr"), controller) {
+        submitWithAuthorisedUserFailure("OBP", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$noMatchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/OBP")
@@ -402,14 +404,14 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     "if the Limited Liability Partnership form is successfully validated:" must {
       "for successful match, status should be 303 and  user should be redirected to review details page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserSuccessOrg("LLP", request.withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$matchUtr"), controller) {
+        submitWithAuthorisedUserSuccessOrg("LLP", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$matchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
         }
       }
       "for unsuccessful match, status should be Redirect and user should be on details not found page" in new Setup {
-        submitWithAuthorisedUserFailure("LLP", request.withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$noMatchUtr"), controller) {
+        submitWithAuthorisedUserFailure("LLP", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$noMatchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/LLP")
@@ -420,14 +422,14 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     "if the Limited Partnership form is successfully validated:" must {
       "for successful match, status should be 303 and user should be redirected to review details page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserSuccessOrg("LP", request.withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$matchUtr"), controller) {
+        submitWithAuthorisedUserSuccessOrg("LP", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$matchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
         }
       }
       "for unsuccessful match, status should be Redirect and user should be on details not found page" in new Setup {
-        submitWithAuthorisedUserFailure("LP", request.withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$noMatchUtr"), controller) {
+        submitWithAuthorisedUserFailure("LP", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "psaUTR" -> s"$noMatchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/LP")
@@ -438,15 +440,17 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     "if the Sole Trader form  is successfully validated:" must {
       "for successful match, status should be 303 and  user should be redirected to review details page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserSuccessIndividual("SOP", request.withFormUrlEncodedBody("firstName" -> "First Name", "lastName" -> "Last Name", "saUTR" -> s"$matchUtr"), controller) {
+        submitWithAuthorisedUserSuccessIndividual("SOP", FakeRequest("POST", "/").withFormUrlEncodedBody("firstName" -> "First Name", "lastName" -> "Last Name", "saUTR" -> s"$matchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
         }
       }
       "for unsuccessful match, status should be Redirect and user should be on details not found page" in new Setup {
-        submitWithAuthorisedUserFailureIndividual("SOP", request.withFormUrlEncodedBody("firstName" -> "First Name", "lastName" -> "Last Name", "saUTR" -> s"$noMatchUtr"), controller) {
-          result =>
+        submitWithAuthorisedUserFailureIndividual("SOP",
+          FakeRequest("POST", "/").withFormUrlEncodedBody(Map("firstName" -> "First Name", "lastName" -> "Last Name", "saUTR" -> s"$noMatchUtr").toSeq: _*),
+          controller
+        ) { result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/SOP")
         }
@@ -456,14 +460,14 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     "if the Non Resident Landlord is successfully validated:" must {
       "for successful match, status should be 303 and  user should be redirected to review details page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserSuccessOrg("NRL", request.withFormUrlEncodedBody("businessName" -> "Business Name", "saUTR" -> s"$matchUtr"), controller) {
+        submitWithAuthorisedUserSuccessOrg("NRL", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "saUTR" -> s"$matchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
         }
       }
       "for unsuccessful match, status should be Redirect and  user should be on details not found page" in new Setup {
-        submitWithAuthorisedUserFailure("NRL", request.withFormUrlEncodedBody("businessName" -> "Business Name", "saUTR" -> s"$noMatchUtr"), controller) {
+        submitWithAuthorisedUserFailure("NRL", FakeRequest("POST", "/").withFormUrlEncodedBody("businessName" -> "Business Name", "saUTR" -> s"$noMatchUtr"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/NRL")
@@ -475,14 +479,14 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     "if the Unincorporated body form  is successfully validated:" must {
       "for successful match, status should be 303 and  user should be redirected to review details page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserSuccessOrg("UIB", request.withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserSuccessOrg("UIB", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
         }
       }
       "for unsuccessful match, status should be Redirect and  user should be on same details not found page" in new Setup {
-        submitWithAuthorisedUserFailure("UIB", request.withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserFailure("UIB", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/UIB")
@@ -493,14 +497,14 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
     "if the Limited Company form  is successfully validated:" must {
       "for successful match, status should be 303 and  user should be redirected to review details page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserSuccessOrg("LTD", request.withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserSuccessOrg("LTD", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
         }
       }
       "for unsuccessful match, status should be Redirect and user should be on details not found page" in new Setup {
-        submitWithAuthorisedUserFailure("LTD", request.withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserFailure("LTD", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/LTD")
@@ -510,7 +514,7 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
 
     "if the Unit Trust form  is successfully validated:" must {
       "for successful match, status should be 303 and  user should be redirected to review details page" in new Setup {
-        submitWithAuthorisedUserSuccessOrg("UT", request.withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserSuccessOrg("UT", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
@@ -518,7 +522,7 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
       }
       "for unsuccessful match, status should be Redirect and user should be on details not found page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserFailure("UT", request.withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserFailure("UT", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/UT")
@@ -528,7 +532,7 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
 
     "if the Unlimited Company form  is successfully validated:" must {
       "for successful match, status should be 303 and  user should be redirected to review details page" in new Setup {
-        submitWithAuthorisedUserSuccessOrg("ULTD", request.withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserSuccessOrg("ULTD", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$matchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/review-details/$service")
@@ -536,7 +540,7 @@ class BusinessVerificationValidationSpec extends PlaySpec with GuiceOneServerPer
       }
       "for unsuccessful match, status should be Redirect and user should be on details not found page" in new Setup {
         when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-        submitWithAuthorisedUserFailure("ULTD", request.withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
+        submitWithAuthorisedUserFailure("ULTD", FakeRequest("POST", "/").withFormUrlEncodedBody("cotaxUTR" -> s"$noMatchUtr", "businessName" -> "Business Name"), controller) {
           result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-verification/$service/detailsNotFound/ULTD")

--- a/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package controllers.nonUKReg
 
+import java.util.UUID
+
 import config.ApplicationConfig
 import connectors.{BackLinkCacheConnector, BusinessRegCacheConnector}
 import models.{Address, BusinessRegistration}
@@ -24,7 +26,7 @@ import org.mockito.{ArgumentMatchers, MockitoSugar}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
@@ -32,9 +34,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.NotFoundException
 import views.html.nonUkReg.business_registration
 
-import java.util.UUID
 import scala.concurrent.Future
-
 
 class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with Injecting {
 
@@ -156,21 +156,17 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
                        line3: String = "",
                        line4: String = "",
                        postcode: String = "12345678",
-                       country: String = "FR") =
-          Json.parse(
-            s"""
-               |{
-               |  "businessName": "$businessName",
-               |  "businessAddress": {
-               |    "line_1": "$line1",
-               |    "line_2": "$line2",
-               |    "line_3": "$line3",
-               |    "line_4": "$line4",
-               |    "postcode": "$postcode",
-               |    "country": "$country"
-               |  }
-               |}
-          """.stripMargin)
+                       country: String = "FR") = {
+          Map(
+            "businessName" -> s"$businessName",
+            "businessAddress.line_1" -> s"$line1",
+            "businessAddress.line_2" -> s"$line2",
+            "businessAddress.line_3" -> s"$line3",
+            "businessAddress.line_4" -> s"$line4",
+            "businessAddress.postcode" -> s"$postcode",
+            "businessAddress.country" -> s"$country"
+          )
+        }
 
         type InputJson = JsValue
         type TestMessage = String
@@ -180,7 +176,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
           val inputJson = createJson(businessName = "", line1 = "", line2 = "", postcode = "", country = "")
           when(mockBackLinkCache.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
 
-          submitWithAuthorisedUserSuccess(serviceName, FakeRequest().withJsonBody(inputJson)) { result =>
+          submitWithAuthorisedUserSuccess(serviceName, FakeRequest("POST", "/").withFormUrlEncodedBody(inputJson.toSeq: _*)) { result =>
             status(result) must be(BAD_REQUEST)
             contentAsString(result) must include("Enter a business name")
             contentAsString(result) must include("Enter address line 1")
@@ -191,7 +187,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         }
 
         // inputJson , test message, error message
-        val formValidationInputDataSet: Seq[(InputJson, TestMessage, ErrorMessage)] = Seq(
+        val formValidationInputDataSet: Seq[(Map[String, String], TestMessage, ErrorMessage)] = Seq(
           (createJson(businessName = "a" * 106), "If entered, Business name must be maximum of 105 characters", "The business name cannot be more than 105 characters"),
           (createJson(line1 = "a" * 36), "If entered, Address line 1 must be maximum of 35 characters", "Address line 1 cannot be more than 35 characters"),
           (createJson(line2 = "a" * 36), "If entered, Address line 2 must be maximum of 35 characters", "Address line 2 cannot be more than 35 characters"),
@@ -204,7 +200,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         formValidationInputDataSet.foreach { data =>
           s"${data._2}" in {
             when(mockBackLinkCache.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-            submitWithAuthorisedUserSuccess(serviceName, FakeRequest().withJsonBody(data._1)) { result =>
+            submitWithAuthorisedUserSuccess(serviceName, FakeRequest("POST", "/").withFormUrlEncodedBody(data._1.toSeq: _*)) { result =>
               status(result) must be(BAD_REQUEST)
               contentAsString(result) must include(data._3)
             }
@@ -214,7 +210,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         "If registration details entered are valid, continue button must redirect to review details page" in {
           when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
           val inputJson = createJson()
-          submitWithAuthorisedUserSuccess(serviceName, FakeRequest().withJsonBody(inputJson)) { result =>
+          submitWithAuthorisedUserSuccess(serviceName, FakeRequest("POST", "/").withFormUrlEncodedBody(inputJson.toSeq: _*)) { result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/register/non-uk-client/overseas-company/$serviceName/false")
           }
@@ -223,7 +219,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         "If registration details entered are valid and business-identifier question is selected as No, continue button must redirect to review details page" in {
           val inputJson = createJson()
           when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-          submitWithAuthorisedUserSuccess(serviceName, FakeRequest().withJsonBody(inputJson)) { result =>
+          submitWithAuthorisedUserSuccess(serviceName, FakeRequest("POST", "/").withFormUrlEncodedBody(inputJson.toSeq: _*)) { result =>
             status(result) must be(SEE_OTHER)
             redirectLocation(result).get must include(s"/business-customer/register/non-uk-client/overseas-company/$serviceName/false")
           }
@@ -231,42 +227,77 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
 
 
         "fail if we are a client for ATED and have no PostCode" in {
-          val inputJson = createJson(postcode = "")
           when(mockBackLinkCache.fetchAndGetBackLink(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-          submitWithAuthorisedUserSuccess(serviceName, FakeRequest().withJsonBody(inputJson)) { result =>
+          submitWithAuthorisedUserSuccess(serviceName, FakeRequest("POST", "/").withFormUrlEncodedBody(Map(
+            "businessName" -> "ACME",
+            "businessAddress.line_1" -> "line_1",
+            "businessAddress.line_2" -> "line_2",
+            "businessAddress.line_3" -> "",
+            "businessAddress.line_4" -> "",
+            "businessAddress.postcode" -> "",
+            "businessAddress.country" -> "FR"
+          ).toSeq: _*)) { result =>
             status(result) must be(BAD_REQUEST)
           }
         }
 
         "pass if we are a client for AWRS and have no PostCode" in {
-          val inputJson = createJson(postcode = "")
           when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-          submitWithAuthorisedUserSuccess("AWRS", FakeRequest().withJsonBody(inputJson)) { result =>
+          submitWithAuthorisedUserSuccess("AWRS", FakeRequest("POST", "/").withFormUrlEncodedBody(Map(
+            "businessName" -> "ACME",
+            "businessAddress.line_1" -> "line_1",
+            "businessAddress.line_2" -> "line_2",
+            "businessAddress.line_3" -> "",
+            "businessAddress.line_4" -> "",
+            "businessAddress.postcode" -> "",
+            "businessAddress.country" -> "FR"
+          ).toSeq: _*)) { result =>
             status(result) must be(SEE_OTHER)
           }
         }
 
         "pass if we are an agent for ATED and have no PostCode" in {
-          val inputJson = createJson(postcode = "")
           when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-          submitWithAuthorisedAgent(serviceName, FakeRequest().withJsonBody(inputJson)) { result =>
+          submitWithAuthorisedAgent(serviceName, FakeRequest("POST", "/").withFormUrlEncodedBody(Map(
+            "businessName" -> "ACME",
+            "businessAddress.line_1" -> "line_1",
+            "businessAddress.line_2" -> "line_2",
+            "businessAddress.line_3" -> "",
+            "businessAddress.line_4" -> "",
+            "businessAddress.postcode" -> "",
+            "businessAddress.country" -> "FR"
+          ).toSeq: _*)) { result =>
             status(result) must be(SEE_OTHER)
           }
         }
 
         "pass if we are an agent for AWRS and have no PostCode" in {
-          val inputJson = createJson(postcode = "")
           when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
-          submitWithAuthorisedAgent("AWRS", FakeRequest().withJsonBody(inputJson)) { result =>
+          submitWithAuthorisedAgent("AWRS", FakeRequest("POST", "/").withFormUrlEncodedBody(Map(
+            "businessName" -> "ACME",
+            "businessAddress.line_1" -> "line_1",
+            "businessAddress.line_2" -> "line_2",
+            "businessAddress.line_3" -> "",
+            "businessAddress.line_4" -> "",
+            "businessAddress.postcode" -> "",
+            "businessAddress.country" -> "FR"
+          ).toSeq: _*)) { result =>
             status(result) must be(SEE_OTHER)
           }
         }
 
         "respond with NotFound when invalid service is in uri" in {
-          val inputJson = createJson(postcode = "")
           when(mockBackLinkCache.saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(Future.successful(None))
           intercept[NotFoundException] {
-            submitWithAuthorisedAgent(invalidService, FakeRequest().withJsonBody(inputJson)) { result =>
+            submitWithAuthorisedAgent(invalidService, FakeRequest("POST", "/").withFormUrlEncodedBody(Map(
+              "businessName" -> "ACME",
+              "businessAddress.line_1" -> "line_1",
+              "businessAddress.line_2" -> "line_2",
+              "businessAddress.line_3" -> "",
+              "businessAddress.line_4" -> "",
+              "businessAddress.postcode" -> "",
+              "businessAddress.country" -> "FR"
+            ).toSeq: _*)) { result =>
               status(result) must be(NOT_FOUND)
             }
           }
@@ -364,7 +395,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
     test(result)
   }
 
-  def submitWithAuthorisedUserSuccess(service: String, fakeRequest: FakeRequest[AnyContentAsJson], businessType: String = "NUK")(test: Future[Result] => Any) {
+  def submitWithAuthorisedUserSuccess(service: String, fakeRequest: FakeRequest[AnyContentAsFormUrlEncoded], businessType: String = "NUK")(test: Future[Result] => Any) {
     val sessionId = s"session-${UUID.randomUUID}"
     val userId = s"user-${UUID.randomUUID}"
 
@@ -385,7 +416,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
     test(result)
   }
 
-  def submitWithAuthorisedAgent(service: String, fakeRequest: FakeRequest[AnyContentAsJson], businessType: String = "NUK")(test: Future[Result] => Any) {
+  def submitWithAuthorisedAgent(service: String, fakeRequest: FakeRequest[AnyContentAsFormUrlEncoded], businessType: String = "NUK")(test: Future[Result] => Any) {
     val sessionId = s"session-${UUID.randomUUID}"
     val userId = s"user-${UUID.randomUUID}"
 


### PR DESCRIPTION
DL-7795 bootstrap-play and play 2.8.15 upgrades

**New feature**

Upgraded to use bootstrap-play 5.24.0  and play 2.8.15 . This is to protect against a security vulnerability that has been found in Play, and comes of the back of this [techspace blog](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=447906456).

I had to change AnyContentAsJson implementations to AnyContentAsFormUrlEncoded in order to comply with the upgrade.

## Checklist Reviewee (Iyke)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
 ## Checklist Reviewer (add name here)
 
  - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
  - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
  - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
  - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
  - [ ]  I've run a dependency check to ensure all dependencies are up to date
