### PR TITLE
Fixed backLink bug on LLP page businessForm page and fixed warns

### DIFF
--- a/app/controllers/BusinessVerificationController.scala
+++ b/app/controllers/BusinessVerificationController.scala
@@ -198,9 +198,7 @@ class BusinessVerificationController @Inject()(val config: ApplicationConfig,
                               backLink: Option[String])
                              (implicit authContext: StandardAuthRetrievals, req: Request[AnyContent]): Future[Result] = {
     limitedLiabilityPartnershipForm.bindFromRequest.fold(
-      formWithErrors => currentBackLink.map(implicit backLink =>
-        BadRequest(templateLLP(formWithErrors, authContext.isAgent, service, businessType, backLink))
-      ),
+      formWithErrors => Future.successful(BadRequest(templateLLP(formWithErrors, authContext.isAgent, service, businessType, backLink))),
       llpFormData => {
         val organisation = Organisation(llpFormData.businessName, Llp)
         businessMatchingService.matchBusinessWithOrganisationName(isAnAgent = authContext.isAgent,

--- a/test/builders/SessionBuilder.scala
+++ b/test/builders/SessionBuilder.scala
@@ -18,7 +18,7 @@ package builders
 
 import java.util.UUID
 
-import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, AnyContentAsJson, Headers}
+import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Headers}
 import play.api.test.FakeRequest
 
 object SessionBuilder {

--- a/test/controllers/BusinessRegUKControllerSpec.scala
+++ b/test/controllers/BusinessRegUKControllerSpec.scala
@@ -25,7 +25,6 @@ import org.jsoup.Jsoup
 import org.mockito.{ArgumentMatchers, MockitoSugar}
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/nonUKReg/AgentRegisterNonUKClientControllerSpec.scala
+++ b/test/controllers/nonUKReg/AgentRegisterNonUKClientControllerSpec.scala
@@ -26,7 +26,6 @@ import org.mockito.{ArgumentMatchers, MockitoSugar}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
@@ -179,7 +178,6 @@ class AgentRegisterNonUKClientControllerSpec extends PlaySpec with GuiceOneServe
           )
         }
 
-        type InputJson = JsValue
         type TestMessage = String
         type ErrorMessage = String
 

--- a/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
@@ -26,7 +26,6 @@ import org.mockito.{ArgumentMatchers, MockitoSugar}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
@@ -168,7 +167,6 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
           )
         }
 
-        type InputJson = JsValue
         type TestMessage = String
         type ErrorMessage = String
 

--- a/test/controllers/nonUKReg/OverseasCompanyRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/OverseasCompanyRegControllerSpec.scala
@@ -28,7 +28,6 @@ import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
@@ -122,7 +121,6 @@ class OverseasCompanyRegControllerSpec extends PlaySpec with GuiceOneServerPerSu
         isAGroup = false, directMatch = false, Some("agent123"))
 
       "validate form" must {
-        type InputJson = JsValue
         type TestMessage = String
         type ErrorMessage = String
 

--- a/test/controllers/nonUKReg/UpdateNonUKBusinessRegistrationControllerSpec.scala
+++ b/test/controllers/nonUKReg/UpdateNonUKBusinessRegistrationControllerSpec.scala
@@ -27,7 +27,6 @@ import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/nonUKReg/UpdateOverseasCompanyRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/UpdateOverseasCompanyRegControllerSpec.scala
@@ -27,7 +27,6 @@ import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}


### PR DESCRIPTION
# DL-7676

**Bug fix**

Fixed an issue where the LLP businessForm page would incorrectly set the back link href after triggering validation errors

## Checklist Reviewee (add name here)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
 ## Checklist Reviewer (add name here)
 
  - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
  - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
  - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
  - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
  - [x]  I've run a dependency check to ensure all dependencies are up to date
