### PR TITLE
DL-17676: adds numeric inputmode and pattern to utr

### DIFF
--- a/app/views/business_lookup_LLP.scala.html
+++ b/app/views/business_lookup_LLP.scala.html
@@ -103,6 +103,10 @@
                     label = Label(
                         content = Text(Messages("bc.business-verification.coUTRFieldpsaUTR")),
                         classes = "govuk-visually-hidden"
+                    ),
+                    attributes = Map(
+                        "inputmode" -> "numeric",
+                        "pattern" -> "[0-9]*"
                     )
                 ).withFormField(limitedLiabilityPartnershipForm("psaUTR"))
             )

--- a/app/views/business_lookup_LP.scala.html
+++ b/app/views/business_lookup_LP.scala.html
@@ -102,6 +102,10 @@
                     label = Label(
                         content = Text(Messages("bc.business-verification.coUTRFieldpsaUTR")),
                         classes = "govuk-visually-hidden"
+                    ),
+                    attributes = Map(
+                        "inputmode" -> "numeric",
+                        "pattern" -> "[0-9]*"
                     )
                 ).withFormField(limitedPartnershipForm("psaUTR"))
             )

--- a/app/views/business_lookup_LTD.scala.html
+++ b/app/views/business_lookup_LTD.scala.html
@@ -102,18 +102,22 @@
                         content = Text(Messages("bc.business-verification.coUTRField")),
                         classes = "govuk-visually-hidden"
                     ),
-                     hint = Some(Hint(
-            content = HtmlContent(
-                 s"""
-                    <p class="govuk-body govuk-hint">${Messages("bc.business-verification.utr.corporationUTR")}</p>
-                    <p class="govuk-body govuk-hint">
-                        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/find-utr-number">
-                            ${Messages("bc.business-verification.utr.corporationUTRLink")}
-                        </a>
-                    </p>
-                """
-            )
-        )),
+                    hint = Some(Hint(
+                        content = HtmlContent(
+                            s"""
+                                <p class="govuk-body govuk-hint">${Messages("bc.business-verification.utr.corporationUTR")}</p>
+                                <p class="govuk-body govuk-hint">
+                                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/find-utr-number">
+                                        ${Messages("bc.business-verification.utr.corporationUTRLink")}
+                                    </a>
+                                </p>
+                            """
+                        )
+                    )),
+                    attributes = Map(
+                        "inputmode" -> "numeric",
+                        "pattern" -> "[0-9]*"
+                    )
                 ).withFormField(limitedCompanyForm("cotaxUTR"))
             )
 

--- a/app/views/business_lookup_NRL.scala.html
+++ b/app/views/business_lookup_NRL.scala.html
@@ -107,6 +107,10 @@
                     label = Label(
                         content = Text(Messages("bc.business-verification.coUTRFieldsaUTR")),
                         classes = "govuk-visually-hidden"
+                    ),
+                    attributes = Map(
+                        "inputmode" -> "numeric",
+                        "pattern" -> "[0-9]*"
                     )
                 ).withFormField(nrlForm("saUTR"))
             )

--- a/app/views/business_lookup_OBP.scala.html
+++ b/app/views/business_lookup_OBP.scala.html
@@ -102,6 +102,10 @@
                     label = Label(
                         content = Text(Messages("bc.business-verification.coUTRFieldpsaUTR")),
                         classes = "govuk-visually-hidden"
+                    ),
+                    attributes = Map(
+                        "inputmode" -> "numeric",
+                        "pattern" -> "[0-9]*"
                     )
                 ).withFormField(ordinaryBusinessPartnershipForm("psaUTR"))
             )

--- a/app/views/business_lookup_SOP.scala.html
+++ b/app/views/business_lookup_SOP.scala.html
@@ -111,6 +111,10 @@
                     label = Label(
                         content = Text(Messages("bc.business-verification.coUTRFieldsaUTR")),
                         classes = "govuk-visually-hidden"
+                    ),
+                    attributes = Map(
+                        "inputmode" -> "numeric",
+                        "pattern" -> "[0-9]*"
                     )
                 ).withFormField(soleTraderForm("saUTR"))
             )

--- a/app/views/business_lookup_UIB.scala.html
+++ b/app/views/business_lookup_UIB.scala.html
@@ -108,9 +108,12 @@
                                     </a>
                                 </p>
                             """
-            )
-        ))
-                    
+                        )
+                    )),
+                    attributes = Map(
+                        "inputmode" -> "numeric",
+                        "pattern" -> "[0-9]*"
+                    )
                 ).withFormField(unincorporatedBodyForm("cotaxUTR"))
             )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,15 +21,15 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc"  %% "bootstrap-frontend-play-30"   % "10.1.0",
+    "uk.gov.hmrc"  %% "bootstrap-frontend-play-30"   % "10.3.0",
     "uk.gov.hmrc"  %% "domain-play-30"               % "11.0.0",
-    "uk.gov.hmrc"  %% "play-partials-play-30"        % "10.1.0",
-    "uk.gov.hmrc"  %% "play-frontend-hmrc-play-30"   % "12.8.0",
+    "uk.gov.hmrc"  %% "play-partials-play-30"        % "10.2.0",
+    "uk.gov.hmrc"  %% "play-frontend-hmrc-play-30"   % "12.18.0",
     "uk.gov.hmrc"  %% "http-caching-client-play-30"   % "12.2.0",
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % "10.1.0"    % Test
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % "10.3.0"    % Test
   )
   val itDependencies: Seq[ModuleID] = Seq()
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.8")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.9")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.3.1")
 


### PR DESCRIPTION
A numeric keypad is not provided when populating input fields that require whole numbers. This PR adds the inputmode and pattern to the text input to fix this.