### PR TITLE
DL-18141 - adds service name to page titles

### DIFF
--- a/app/views/details_not_found.scala.html
+++ b/app/views/details_not_found.scala.html
@@ -38,7 +38,7 @@
     }
 }
 
-@bcMain(title = titleBuilder(messages("bc.details-not-found.header")), service = service, backlink=Some(backLinkHtml)) {
+@bcMain(title = titleBuilder(messages("bc.details-not-found.header"), None, Some(service)), service = service, backlink=Some(backLinkHtml)) {
 
   @if(isAgent) {
     <span class="govuk-caption-xl hmrc-caption-xl" id="business-verification-agent-text">@messages("bc.business-verification.agent.text", service.toUpperCase)</span>

--- a/app/views/nonUkReg/nrl_question.scala.html
+++ b/app/views/nonUkReg/nrl_question.scala.html
@@ -38,7 +38,7 @@
     }
 }
 
-@bcMain(title = titleBuilder(messages("bc.nrl.title"), Some(nrlQuestionForm)), service = service, backlink=Some(backLinkHtml)) {
+@bcMain(title = titleBuilder(messages("bc.nrl.title"), Some(nrlQuestionForm), Some(service)), service = service, backlink=Some(backLinkHtml)) {
 
     @if(nrlQuestionForm.errors.nonEmpty) {
         @govukErrorSummary(ErrorSummary().withFormErrorsAsText(nrlQuestionForm))

--- a/app/views/nonUkReg/paySAQuestion.scala.html
+++ b/app/views/nonUkReg/paySAQuestion.scala.html
@@ -40,7 +40,7 @@
     }
 }
 
-@bcMain(title = titleBuilder(messages("bc.nonuk.paySA.title"), Some(paySAQuestionForm)), service = service,
+@bcMain(title = titleBuilder(messages("bc.nonuk.paySA.title"), Some(paySAQuestionForm), Some(service)), service = service,
   backlink=Some(backLinkHtml)) {
 
     @if(paySAQuestionForm.errors.nonEmpty) {

--- a/app/views/nonUkReg/update_business_registration.scala.html
+++ b/app/views/nonUkReg/update_business_registration.scala.html
@@ -64,7 +64,7 @@
     }
 }
 
-@bcMain(title = titleBuilder(messages(displayDetails.businessRegHeader), Some(businessRegistrationForm)),
+@bcMain(title = titleBuilder(messages(displayDetails.businessRegHeader), Some(businessRegistrationForm), Some(service)),
   service = service, pageScripts = Some(pageScripts), backlink=Some(backLinkHtml)) {
 
     @if(businessRegistrationForm.errors.nonEmpty) {

--- a/app/views/nonUkReg/update_overseas_company_registration.scala.html
+++ b/app/views/nonUkReg/update_overseas_company_registration.scala.html
@@ -111,7 +111,7 @@
     }
 }
 
-@bcMain(title = titleBuilder(messages(displayDetails.title), Some(overseasCompanyForm)), service = service,
+@bcMain(title = titleBuilder(messages(displayDetails.title), Some(overseasCompanyForm), Some(service)), service = service,
   pageScripts = Some(pageScripts), backlink=Some(backLinkHtml)) {
 
     @if(overseasCompanyForm.errors.nonEmpty) {

--- a/app/views/review_details.scala.html
+++ b/app/views/review_details.scala.html
@@ -86,7 +86,7 @@
     }
 }
 
-@bcMain(title = titleBuilder(headingText), service = service, backlink=Some(backLinkHtml)) {
+@bcMain(title = titleBuilder(headingText, None, Some(service)), service = service, backlink=Some(backLinkHtml)) {
 
     <header>
         <h1 class="govuk-heading-xl">

--- a/app/views/review_details_non_uk_agent.scala.html
+++ b/app/views/review_details_non_uk_agent.scala.html
@@ -37,7 +37,7 @@
     }
 }
 
-@bcMain(title = titleBuilder(messages("business-review.agent-editable.title", service, Some(service))), service = service,
+@bcMain(title = titleBuilder(messages("business-review.agent-editable.title", service), None, Some(service)), service = service,
   backlink=Some(backLinkHtml)) {
 
     <header>

--- a/conf/messages
+++ b/conf/messages
@@ -8,6 +8,7 @@ bc.screen-reader.section = This section is:
 bc.screen-reader.name = this is for:
 
 bc.ated.serviceName = Register for ATED
+bc.ATED.serviceName = Register for ATED
 bc.awrs.serviceName = Register as an alcohol wholesaler or producer
 bc.amls.serviceName = Anti Money Laundering Supervision
 bc.fhdds.serviceName = Apply for the Fulfilment House Due Diligence Scheme

--- a/test/controllers/BusinessVerificationControllerSpec.scala
+++ b/test/controllers/BusinessVerificationControllerSpec.scala
@@ -185,7 +185,7 @@ class BusinessVerificationControllerSpec
           businessVerificationWithAuthorisedUser(controller) { result =>
             val document = Jsoup.parse(contentAsString(result))
 
-            document.title() must be("What is your business type? - GOV.UK")
+            document.title() must be("What is your business type? - Register for ATED - GOV.UK")
             document.getElementsByClass("govuk-caption-xl").text() must be(
               "This section is ATED registration"
             )
@@ -283,7 +283,7 @@ class BusinessVerificationControllerSpec
             val document = Jsoup.parse(contentAsString(result))
 
             document.title() must be(
-              "What is the business type for your agency? - GOV.UK"
+              "What is the business type for your agency? - Register for ATED - GOV.UK"
             )
             document.getElementsByClass("govuk-caption-xl").text() must be(
               "This section is ATED agency set up"

--- a/test/controllers/nonUKReg/AgentRegisterNonUKClientControllerSpec.scala
+++ b/test/controllers/nonUKReg/AgentRegisterNonUKClientControllerSpec.scala
@@ -95,7 +95,7 @@ class AgentRegisterNonUKClientControllerSpec extends PlaySpec with GuiceOneServe
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is your client’s overseas registered business name and address? - GOV.UK")
+          document.title() must be("What is your client’s overseas registered business name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: Add a client")
           document.getElementsByTag("h1").text() must include("What is your client’s overseas registered business name and address?")
           document.getElementsByAttributeValue("for", "businessName").text() must be("Business name")
@@ -119,7 +119,7 @@ class AgentRegisterNonUKClientControllerSpec extends PlaySpec with GuiceOneServe
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is your client’s overseas registered business name and address? - GOV.UK")
+          document.title() must be("What is your client’s overseas registered business name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: Add a client")
           document.getElementsByTag("h1").text() must include("What is your client’s overseas registered business name and address?")
           document.getElementsByAttributeValue("for", "businessName").text() must be("Business name")
@@ -146,7 +146,7 @@ class AgentRegisterNonUKClientControllerSpec extends PlaySpec with GuiceOneServe
           verify(mockBackLinkCache, times(1)).
             saveBackLink(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
 
-          document.title() must be("What is your client’s overseas registered business name and address? - GOV.UK")
+          document.title() must be("What is your client’s overseas registered business name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: Add a client")
           document.getElementsByTag("h1").text() must include("What is your client’s overseas registered business name and address?")
           document.getElementsByAttributeValue("for", "businessName").text() must be("Business name")
@@ -169,7 +169,7 @@ class AgentRegisterNonUKClientControllerSpec extends PlaySpec with GuiceOneServe
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is your client’s overseas registered business name and address? - GOV.UK")
+          document.title() must be("What is your client’s overseas registered business name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: Add a client")
           document.getElementsByTag("h1").text() must include("What is your client’s overseas registered business name and address?")
           document.getElementsByAttributeValue("for", "businessName").text() must be("Business name")
@@ -195,7 +195,7 @@ class AgentRegisterNonUKClientControllerSpec extends PlaySpec with GuiceOneServe
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is your client’s overseas registered business name and address? - GOV.UK")
+          document.title() must be("What is your client’s overseas registered business name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: Add a client")
           document.getElementsByTag("h1").text() must include("What is your client’s overseas registered business name and address?")
           document.getElementById("businessName").`val`() must be("ACME")

--- a/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/BusinessRegControllerSpec.scala
@@ -94,7 +94,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is your overseas business registered name and address? - GOV.UK")
+          document.title() must be("What is your overseas business registered name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: ATED registration")
           document.select("h1").text must include("What is your overseas business registered name and address?")
           document.getElementsByAttributeValue("for", "businessName").text() must be("Business name")
@@ -115,7 +115,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is your overseas business registered name and address? - GOV.UK")
+          document.title() must be("What is your overseas business registered name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: ATED registration")
           document.select("h1").text must include("What is your overseas business registered name and address?")
           document.getElementById("businessName").`val`() must be("ACME")
@@ -132,7 +132,7 @@ class BusinessRegControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is the registered business name and address of your overseas agency? - GOV.UK")
+          document.title() must be("What is the registered business name and address of your overseas agency? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: ATED agency set up")
           document.select("h1").text must include("What is the registered business name and address of your overseas agency?")
           document.getElementsByAttributeValue("for", "businessName").text() must be("Business name")

--- a/test/controllers/nonUKReg/NRLQuestionControllerSpec.scala
+++ b/test/controllers/nonUKReg/NRLQuestionControllerSpec.scala
@@ -87,7 +87,7 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         viewWithAuthorisedClient(service) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title must be("Are you a non-resident landlord? - GOV.UK")
+          document.title must be("Are you a non-resident landlord? - Anti Money Laundering Supervision - GOV.UK")
         }
       }
 
@@ -95,7 +95,7 @@ class NRLQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wit
         viewWithAuthorisedClientWithSavedData(service) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title must be("Are you a non-resident landlord? - GOV.UK")
+          document.title must be("Are you a non-resident landlord? - Anti Money Laundering Supervision - GOV.UK")
           document.select(".govuk-radios__item").text() must include("Yes")
           document.select(".govuk-radios__item").text() must include("No")
           document.getElementById("paysSA-2").outerHtml() must include("checked")

--- a/test/controllers/nonUKReg/OverseasCompanyRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/OverseasCompanyRegControllerSpec.scala
@@ -92,7 +92,7 @@ class OverseasCompanyRegControllerSpec extends PlaySpec with GuiceOneServerPerSu
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("Do you have an overseas company registration number? - GOV.UK")
+          document.title() must be("Do you have an overseas company registration number? - Register for ATED - GOV.UK")
         }
       }
 
@@ -107,7 +107,7 @@ class OverseasCompanyRegControllerSpec extends PlaySpec with GuiceOneServerPerSu
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("Does your client have an overseas company registration number? - GOV.UK")
+          document.title() must be("Does your client have an overseas company registration number? - Register for ATED - GOV.UK")
         }
       }
 

--- a/test/controllers/nonUKReg/PaySAQuestionControllerSpec.scala
+++ b/test/controllers/nonUKReg/PaySAQuestionControllerSpec.scala
@@ -90,7 +90,7 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         viewWithAuthorisedClient(service) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title must be("Do you pay tax in the UK through Self Assessment? - GOV.UK")
+          document.title must be("Do you pay tax in the UK through Self Assessment? - Anti Money Laundering Supervision - GOV.UK")
           document.select(".govuk-radios__item").text() must include("Yes")
           document.select(".govuk-radios__item").text() must include("No")
           document.getElementById("submit").text() must be("Continue")
@@ -100,7 +100,7 @@ class PaySAQuestionControllerSpec extends PlaySpec with GuiceOneServerPerSuite w
         viewWithAuthorisedClientWistSavedData(service) { result =>
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
-          document.title must be("Do you pay tax in the UK through Self Assessment? - GOV.UK")
+          document.title must be("Do you pay tax in the UK through Self Assessment? - Anti Money Laundering Supervision - GOV.UK")
           document.select(".govuk-radios__item").text() must include("Yes")
           document.select(".govuk-radios__item").text() must include("No")
           document.getElementById("paySA-2").outerHtml() must include("checked")

--- a/test/controllers/nonUKReg/UpdateNonUKBusinessRegistrationControllerSpec.scala
+++ b/test/controllers/nonUKReg/UpdateNonUKBusinessRegistrationControllerSpec.scala
@@ -132,7 +132,7 @@ class UpdateNonUKBusinessRegistrationControllerSpec extends PlaySpec with GuiceO
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is your client’s overseas registered business name and address? - GOV.UK")
+          document.title() must be("What is your client’s overseas registered business name and address? - Register for ATED - GOV.UK")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: Add a client")
           document.getElementsByTag("h1").text() must include("What is your client’s overseas registered business name and address?")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: Add a client")
@@ -210,7 +210,7 @@ class UpdateNonUKBusinessRegistrationControllerSpec extends PlaySpec with GuiceO
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("What is the registered business name and address of your overseas agency? - GOV.UK")
+          document.title() must be("What is the registered business name and address of your overseas agency? - Register for ATED - GOV.UK")
           document.getElementsByTag("h1").text() must include("What is the registered business name and address of your overseas agency?")
           document.getElementsByClass("govuk-caption-xl").text() must be("This section is: ATED agency set up")
 

--- a/test/controllers/nonUKReg/UpdateOverseasCompanyRegControllerSpec.scala
+++ b/test/controllers/nonUKReg/UpdateOverseasCompanyRegControllerSpec.scala
@@ -105,7 +105,7 @@ class UpdateOverseasCompanyRegControllerSpec extends PlaySpec with GuiceOneServe
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("Do you have an overseas company registration number? - GOV.UK")
+          document.title() must be("Do you have an overseas company registration number? - Register for ATED - GOV.UK")
         }
       }
 
@@ -127,7 +127,7 @@ class UpdateOverseasCompanyRegControllerSpec extends PlaySpec with GuiceOneServe
           status(result) must be(OK)
           val document = Jsoup.parse(contentAsString(result))
 
-          document.title() must be("Do you have an overseas company registration number? - GOV.UK")
+          document.title() must be("Do you have an overseas company registration number? - Register for ATED - GOV.UK")
 
         }
       }


### PR DESCRIPTION
This PR adds the service name to the page title, before - GOV.UK

https://design.tax.service.gov.uk/hmrc-design-patterns/page-title/